### PR TITLE
Changed setStatus method in Layers to remove setting updated to true

### DIFF
--- a/golangci-lint.yml
+++ b/golangci-lint.yml
@@ -193,6 +193,7 @@ issues:
         - gci
         - gomnd
         - gosec
+        - dupl
     - path: pkg/controllers
       linters:
         - godot

--- a/pkg/internal/layers/layers.go
+++ b/pkg/internal/layers/layers.go
@@ -171,7 +171,6 @@ func (l *Layer) setStatus(status, reason, message string) {
 	//l.trimConditions()
 	l.addonsLayer.Status.State = status
 	l.addonsLayer.Status.Version = l.addonsLayer.Spec.Version
-	l.updated = true
 }
 
 // StatusDeployed sets the addon layer's status to deployed.


### PR DESCRIPTION
This change is needed because there are scenarios where we do manual
updates rather than trigger an update at the end of the reconcile.

Also added description of logic still to be implemented.