### PR TITLE
Add shortNames to the AddonsLayer CRD

### DIFF
--- a/config/crd/bases/kraan.io_addonslayers.yaml
+++ b/config/crd/bases/kraan.io_addonslayers.yaml
@@ -5,7 +5,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
-  creationTimestamp: null
   name: addonslayers.kraan.io
 spec:
   group: kraan.io
@@ -14,6 +13,10 @@ spec:
     listKind: AddonsLayerList
     plural: addonslayers
     singular: addonslayer
+    shortNames:
+    - addonlayer
+    - layer
+    - al
   scope: Cluster
   subresources:
     status: {}

--- a/config/crd/bases/kraan.io_addonslayers.yaml
+++ b/config/crd/bases/kraan.io_addonslayers.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
+  creationTimestamp: null
   name: addonslayers.kraan.io
 spec:
   group: kraan.io
@@ -12,11 +13,11 @@ spec:
     kind: AddonsLayer
     listKind: AddonsLayerList
     plural: addonslayers
-    singular: addonslayer
     shortNames:
-    - addonlayer
-    - layer
     - al
+    - layer
+    - addonlayer
+    singular: addonslayer
   scope: Cluster
   subresources:
     status: {}

--- a/pkg/api/v1alpha1/addons_types.go
+++ b/pkg/api/v1alpha1/addons_types.go
@@ -215,7 +215,7 @@ const (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=al;layer;addonlayer
 // +kubebuilder:subresource:status
 type AddonsLayer struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Adding `al`, `layer` and `addonlayer` shortName aliases to the AddonsLayer Custom Resource Definition.