### PR TITLE
Fix processing flow bug

### DIFF
--- a/pkg/controllers/addons_controller.go
+++ b/pkg/controllers/addons_controller.go
@@ -101,10 +101,6 @@ func (r *AddonsLayerReconciler) processPrune(l layers.Layer) error {
 }
 
 func (r *AddonsLayerReconciler) processApply(l layers.Layer) error {
-	if l.IsUpdated() {
-		return nil
-	}
-
 	ctx := r.Context
 	applier := r.Applier
 
@@ -129,10 +125,6 @@ func (r *AddonsLayerReconciler) processApply(l layers.Layer) error {
 }
 
 func (r *AddonsLayerReconciler) checkSuccess(l layers.Layer) error {
-	if l.IsUpdated() {
-		return nil
-	}
-
 	ctx := r.Context
 	applier := r.Applier
 
@@ -161,12 +153,12 @@ func (r *AddonsLayerReconciler) processAddonLayer(l layers.Layer) error {
 	}
 
 	err := r.processPrune(l)
-	if err != nil {
+	if err != nil || l.IsDelayed() {
 		return err
 	}
 
 	err = r.processApply(l)
-	if err != nil {
+	if err != nil || l.IsDelayed() {
 		return err
 	}
 


### PR DESCRIPTION
The use of l.IsUpdated() to determine if processing should continue
turns out to be flawed because the updated flag is only set if the
status is changed and if the status is already what it should be
it is not updated. The updated flag is meant to be used to determine
if the update function should be called at the end of the reconcilation
so using it for this purpose is effectively a misuse.

As it turns out the delayed flag is set if an action is taken that
means the processing should stop and the layer should be requeue after
a delay so we can safely use this flag to suppress further processing.

However this too is a misuse. We should probably add a done flag that
is set when we want the reconcilation processing to cease?

For now I've made this simple change to fix the bug in the short term.