### PR TITLE
Fix GOBIN variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,9 @@
 CRD_OPTIONS ?= "crd"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
+GOBIN := $(shell go env GOBIN)
+ifeq (,$(strip ${GOBIN}))
+GOBIN := $(shell go env GOPATH)/bin
 endif
 
 TOOLS_DIR := hack/tools
@@ -44,7 +43,7 @@ BUILD_ARTIFACT:=${BUILD_DIR}${PROJECT}-build-${VERSION}-docker.tar
 
 GOMOD_CACHE_ARTIFACT:=${GOMOD_CACHE_DIR}._gomod
 GOMOD_VENDOR_ARTIFACT:=${GOMOD_VENDOR_DIR}._gomod
-GO_BIN_ARTIFACT:=$(shell echo "$${GOBIN:-$${GOPATH}/bin}/${PROJECT}")
+GO_BIN_ARTIFACT:=${GOBIN}/${PROJECT}
 GO_DOCS_ARTIFACTS:=$(shell echo $(subst $() $(),\\n,$(ALL_GO_PACKAGES)) | \
 	sed 's:\(.*[/\]\)\(.*\):\1\2/\2.md:')
 


### PR DESCRIPTION
Define the GOBIN variable as a "simply expanded" make variable rather than as a "recursively expanded" variable.

See: [The Two Flavors of Variables](https://www.gnu.org/software/make/manual/make.html#Flavors)

This change immediately stores the output of the invoked `go env GOBIN` shell command as the value rather than expanding the variable (and thus invoking the shell command again) when it's read later on.

If the resulting value is empty or all-spaces, invoke the `go env GOPATH` shell command and append `/bin` before storing the new result as a simply expanded value.

We can then use the GOBIN variable as the file path in GO_BIN_ARTIFACT later without invoking the shell again to obtain the values of GOBIN or GOPATH shell environment variables - which may not be defined for newer versions of `go`.