### PR TITLE
Enable verbose logging

### DIFF
--- a/controllers/addons_controller.go
+++ b/controllers/addons_controller.go
@@ -63,13 +63,13 @@ func NewReconciler(config *rest.Config, client client.Client, logger logr.Logger
 	reconciler = &AddonsLayerReconciler{
 		Config: config,
 		Client: client,
-		Log:    logger,
+		Log:    logger.WithName("reconciler"),
 		Scheme: scheme,
 	}
 	reconciler.k8client = reconciler.getK8sClient()
 	reconciler.Context = context.Background()
 	var err error
-	reconciler.Applier, err = apply.NewApplier(client, logger, scheme)
+	reconciler.Applier, err = apply.NewApplier(client, logger.WithName("applier"), scheme)
 	reconciler.Repos = repos.NewRepos(reconciler.Context, reconciler.Log)
 	return reconciler, err
 }

--- a/pkg/apply/layerApplier.go
+++ b/pkg/apply/layerApplier.go
@@ -74,19 +74,19 @@ func (a KubectlLayerApplier) getLog(layer layers.Layer) (logger logr.Logger) {
 }
 
 func (a KubectlLayerApplier) log(level int, msg string, layer layers.Layer, keysAndValues ...interface{}) {
-	a.getLog(layer).V(level).Info(msg, append(keysAndValues, "sourcePath", layer.GetSourcePath(), "layer", layer)...)
+	a.getLog(layer).V(level).Info(msg, append(keysAndValues, "sourcePath", layer.GetSourcePath())...)
 }
 
 func (a KubectlLayerApplier) logError(err error, msg string, layer layers.Layer, keysAndValues ...interface{}) {
-	a.getLog(layer).Error(err, msg, append(keysAndValues, "sourcePath", layer.GetSourcePath(), "layer", layer)...)
+	a.getLog(layer).Error(err, msg, append(keysAndValues, "sourcePath", layer.GetSourcePath())...)
 }
 
 func (a KubectlLayerApplier) logInfo(msg string, layer layers.Layer, keysAndValues ...interface{}) {
-	a.log(1, msg, layer, keysAndValues...)
+	a.log(0, msg, layer, keysAndValues...)
 }
 
 func (a KubectlLayerApplier) logDebug(msg string, layer layers.Layer, keysAndValues ...interface{}) {
-	a.log(5, msg, layer, keysAndValues...)
+	a.log(1, msg, layer, keysAndValues...)
 }
 
 func (a KubectlLayerApplier) logTrace(msg string, layer layers.Layer, keysAndValues ...interface{}) {
@@ -231,6 +231,7 @@ func (a KubectlLayerApplier) decodeList(layer layers.Layer,
 }
 
 func (a KubectlLayerApplier) checkSourcePath(layer layers.Layer) (sourceDir string, err error) {
+	a.logTrace("Checking layer source directory", layer)
 	sourceDir = layer.GetSourcePath()
 	info, err := os.Stat(sourceDir)
 	if os.IsNotExist(err) {

--- a/pkg/layers/layers.go
+++ b/pkg/layers/layers.go
@@ -87,8 +87,8 @@ type KraanLayer struct {
 }
 
 // CreateLayer creates a layer object.
-func CreateLayer(ctx context.Context, client client.Client, k8client kubernetes.Interface,
-	log logr.Logger, addonsLayer *kraanv1alpha1.AddonsLayer) Layer {
+func CreateLayer(ctx context.Context, client client.Client, k8client kubernetes.Interface, log logr.Logger, addonsLayer *kraanv1alpha1.AddonsLayer) Layer {
+	layerName := fmt.Sprintf("layer-%s", addonsLayer.ObjectMeta.Name)
 	l := &KraanLayer{
 		requeue:     false,
 		delayed:     false,
@@ -96,10 +96,10 @@ func CreateLayer(ctx context.Context, client client.Client, k8client kubernetes.
 		ctx:         ctx,
 		client:      client,
 		k8client:    k8client,
-		log:         log,
 		addonsLayer: addonsLayer,
 	}
 	l.delay = l.addonsLayer.Spec.Interval.Duration
+	l.log = log.WithName(layerName).WithValues("layer", l)
 	return l
 }
 


### PR DESCRIPTION
Enables arbitrarily verbose logging via Zap command-line arguments, obviating the existing flags but we can convert them over later on if necessary.

Set Zap's BindFlags CLI flags at runtime to change the defaults, encoder, log-level or stacktrace-level [as described in the Zap docs](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/log/zap#Options.BindFlags) or [alternate Go Package docs](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.3/pkg/log/zap#Options.BindFlags).

For example; add a `--zap-log-level=7` CLI flag in launch configurations to enable trace logging for `log.V(7).Info(something)` as in the `layerApplier.logTrace(x)` function.

@paulcarlton-ww - try this out and merge it back into the `kraan-controller` branch if you find it useful.  Feel free to alter to suit your needs.

We can then merge the `kraan-controller` branch including these changes and any alterations once you get it working and are happy with that branch.
