### PR TITLE
Update processing of gitrepository syncronization

### DIFF
--- a/pkg/layers/layers.go
+++ b/pkg/layers/layers.go
@@ -39,6 +39,7 @@ type Layer interface {
 	SetStatusK8sVersion()
 	SetStatusApplying()
 	SetStatusPruning()
+	SetStatusPending()
 	SetStatusDeployed()
 	StatusUpdate(status, reason, message string)
 
@@ -46,6 +47,7 @@ type Layer interface {
 	SetHold()
 	DependenciesDeployed() bool
 
+	GetSourceKey() string
 	GetStatus() string
 	GetName() string
 	GetLogger() logr.Logger
@@ -214,6 +216,18 @@ func (l *KraanLayer) SetStatusApplying() {
 func (l *KraanLayer) SetStatusPruning() {
 	l.setStatus(kraanv1alpha1.PruningCondition,
 		kraanv1alpha1.AddonsLayerPruningReason, kraanv1alpha1.AddonsLayerPruningMsg)
+}
+
+// SetStatusPending sets the addon layer's status to pending.
+func (l *KraanLayer) SetStatusPending() {
+	reason := fmt.Sprintf("waiting for layer data to be available.")
+	message := fmt.Sprintf("Layer source: %s, not yet available.", l.GetSourceKey())
+	l.setStatus(kraanv1alpha1.FailedCondition, reason, message)
+}
+
+// GetSourceKey gets the namespace and name of the source used by layer.
+func (l *KraanLayer) GetSourceKey() string {
+	return fmt.Sprintf("%s/%s", l.GetSpec().Source.NameSpace, l.GetSpec().Source.Name)
 }
 
 // StatusUpdate sets the addon layer's status.

--- a/pkg/mocks/layers/mockLayers.go
+++ b/pkg/mocks/layers/mockLayers.go
@@ -72,6 +72,18 @@ func (mr *MockLayerMockRecorder) SetStatusPruning() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatusPruning", reflect.TypeOf((*MockLayer)(nil).SetStatusPruning))
 }
 
+// SetStatusPending mocks base method
+func (m *MockLayer) SetStatusPending() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetStatusPending")
+}
+
+// SetStatusPending indicates an expected call of SetStatusPending
+func (mr *MockLayerMockRecorder) SetStatusPending() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatusPending", reflect.TypeOf((*MockLayer)(nil).SetStatusPending))
+}
+
 // SetStatusDeployed mocks base method
 func (m *MockLayer) SetStatusDeployed() {
 	m.ctrl.T.Helper()
@@ -134,6 +146,20 @@ func (m *MockLayer) DependenciesDeployed() bool {
 func (mr *MockLayerMockRecorder) DependenciesDeployed() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DependenciesDeployed", reflect.TypeOf((*MockLayer)(nil).DependenciesDeployed))
+}
+
+// GetSourceKey mocks base method
+func (m *MockLayer) GetSourceKey() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSourceKey")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetSourceKey indicates an expected call of GetSourceKey
+func (mr *MockLayerMockRecorder) GetSourceKey() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSourceKey", reflect.TypeOf((*MockLayer)(nil).GetSourceKey))
 }
 
 // GetStatus mocks base method

--- a/pkg/mocks/repos/mockRepos.go
+++ b/pkg/mocks/repos/mockRepos.go
@@ -261,6 +261,20 @@ func (mr *MockRepoMockRecorder) GetDataPath() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataPath", reflect.TypeOf((*MockRepo)(nil).GetDataPath))
 }
 
+// GetLoadPath mocks base method
+func (m *MockRepo) GetLoadPath() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLoadPath")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetLoadPath indicates an expected call of GetLoadPath
+func (mr *MockRepoMockRecorder) GetLoadPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadPath", reflect.TypeOf((*MockRepo)(nil).GetLoadPath))
+}
+
 // SetHostName mocks base method
 func (m *MockRepo) SetHostName(hostName string) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This change improves the processing of gitrepository objects which the
controller watches. Now it will only retrieve data from the source
controller for a gitrepository that an addonslayer references.

Also improved mutex handling so we don't block addonslayer processing
while the data is being fetched from the source controller and we
fetch to a separate directory then do an remove/rename to move the
new data into place as quickly as possible.

Finally the reconcile processing now checks if the repository object
is present and waits for up to 15 seconds for it to be created before
updating the symbolic link to the data.