### PR TITLE
use kustomize build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /
 RUN apk add curl
 COPY --from=builder /workspace/kraan-controller /usr/local/bin/
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.12/bin/linux/amd64/kubectl
+RUN curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin
 RUN addgroup -S controller && adduser -S -g controller controller

--- a/pkg/internal/kubectl/export_test.go
+++ b/pkg/internal/kubectl/export_test.go
@@ -22,3 +22,7 @@ func SetKubectlCmd(command string) {
 func SetNewExecProviderFunc(newFunc func() ExecProvider) {
 	newExecProviderFunc = newFunc
 }
+
+func SetNewTempDirProviderFunc(newFunc func() (string, error)) {
+	tempDirProviderFunc = newFunc
+}

--- a/pkg/internal/kubectl/export_test.go
+++ b/pkg/internal/kubectl/export_test.go
@@ -3,6 +3,7 @@ package kubectl
 
 var (
 	KubectlCmd        = kubectlCmd
+	KustomizeCmd      = kustomizeCmd
 	NewCommandFactory = newCommandFactory
 	GetFactoryPath    = CommandFactory.getPath
 	GetLogger         = CommandFactory.getLogger

--- a/pkg/internal/kubectl/kubectl.go
+++ b/pkg/internal/kubectl/kubectl.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 //Package kubectl executes various kubectl sub-commands in a forked shell
 //go:generate mockgen -destination=../mocks/kubectl/mockKubectl.go -package=mocks . Kubectl,Command
-//Disabled go:generate mockgen -destination=../mocks/ioutil/mockLogger.go -package=mocks io/ioutil TempDir
 package kubectl
 
 import (
@@ -37,6 +36,7 @@ var (
 	kustomizeCmd        = "kustomize"
 	applyArgs           = []string{"-R", "-f"}
 	newExecProviderFunc = newExecProvider
+	tempDirProviderFunc = createTempDir
 )
 
 // Kubectl is a Factory interface that returns concrete Command implementations from named constructors.
@@ -164,10 +164,16 @@ func (c *abstractCommand) Run() (output []byte, err error) {
 	return c.output, err
 }
 
+// createTempDir creates a temporary directory.
+func createTempDir() (buildDir string, err error) {
+	buildDir, err = ioutil.TempDir("", "build-*")
+	return buildDir, err
+}
+
 // Build executes the Kustomize command with all its arguments and returns the output.
 func (c *abstractCommand) Build() (buildDir string) {
 	var err error
-	buildDir, err = ioutil.TempDir("", "build-*")
+	buildDir, err = tempDirProviderFunc()
 	if err != nil {
 		c.logError(err) // nolint:errcheck //ok
 		return buildDir

--- a/pkg/internal/kubectl/kubectl.go
+++ b/pkg/internal/kubectl/kubectl.go
@@ -34,6 +34,7 @@ var (
 	applyArgs           = []string{"-R", "-f"}
 	kustomizeApplyArgs  = []string{"-k"}
 	kubectlCmd          = "kubectl"
+	kustomizeCmd        = "kustomize"
 	newExecProviderFunc = newExecProvider
 )
 
@@ -60,6 +61,7 @@ func NewKustomize(logger logr.Logger) (kubectl Kubectl, err error) {
 	execProvider := newExecProviderFunc()
 	return newCommandFactory(logger, execProvider)
 }
+
 // CommandFactory is a concrete Factory implementation of the Kubectl interface's API.
 type CommandFactory struct {
 	logger       logr.Logger
@@ -185,9 +187,10 @@ func kustomizationBuiler(path string, log logr.Logger) string {
 		log.Error(err, "failed to create kustomize command object")
 		return path
 	}
-	kustomize.
+	kustomize.Build()
 	return path
 }
+
 // Apply instantiates an ApplyCommand instance using the provided directory path.
 func (f *CommandFactory) Apply(path string) (c Command) {
 	if f.isKustomization(path) {

--- a/pkg/internal/kubectl/kubectl.go
+++ b/pkg/internal/kubectl/kubectl.go
@@ -33,8 +33,8 @@ const (
 )
 
 var (
-	applyArgs           = []string{"-R", "-f"}
 	kubectlCmd          = "kubectl"
+	applyArgs           = []string{"-R", "-f"}
 	newExecProviderFunc = newExecProvider
 )
 

--- a/pkg/internal/kubectl/kubectl.go
+++ b/pkg/internal/kubectl/kubectl.go
@@ -222,7 +222,7 @@ func (f *CommandFactory) Build(path string) (c Command) {
 			factory:    f,
 			subCmd:     "build",
 			jsonOutput: true,
-			args:       []string{path, "-o"},
+			args:       []string{path},
 		},
 	}
 	return c

--- a/pkg/internal/kubectl/kubectl_test.go
+++ b/pkg/internal/kubectl/kubectl_test.go
@@ -339,7 +339,7 @@ func setupApply(t *testing.T) *Setup {
 }
 
 func setupBuild(t *testing.T) *Setup {
-	s := setup(t, "build", true).WithKustomizeArgs(sourcePath, "-o")
+	s := setup(t, "build", true).WithKustomizeArgs(sourcePath)
 	s.path = "/mocked/path/to/kustomize"
 	return s
 }

--- a/pkg/internal/mocks/kubectl/mockKubectl.go
+++ b/pkg/internal/mocks/kubectl/mockKubectl.go
@@ -107,6 +107,20 @@ func (m *MockCommand) EXPECT() *MockCommandMockRecorder {
 	return m.recorder
 }
 
+// Build mocks base method
+func (m *MockCommand) Build() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Build")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Build indicates an expected call of Build
+func (mr *MockCommandMockRecorder) Build() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockCommand)(nil).Build))
+}
+
 // DryRun mocks base method
 func (m *MockCommand) DryRun() ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/testdata/addons/kraan/namespace.yaml
+++ b/testdata/addons/kraan/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kraan
+  name: kraangit


### PR DESCRIPTION
Turns out that kubectl -k has problems with some kustomization.yaml that kustomize does not.
We may have to use kustomize build to generate yaml then parse that with kubectl apply
Investigating how to add this functionality