### PR TITLE
Move Kraan Controller to gotk-system namespace

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -209,7 +209,7 @@ function toolkit_refresh() {
     gitops_proxy_url="${HTTPS_PROXY}"
   fi
     cp "${work_dir}"/gitops/gitops.yaml "${work_dir}"/gitops/gitops-orignal.yaml
-    awk '/env:/{ print;print "        - name: HTTPS_PROXY\n          value: gitops_proxy_url\n        - name: NO_PROXY\n          value: 10.0.0.0/8";next}1' \
+    awk '/env:/{ print;print "        - name: HTTPS_PROXY\n          value: gitops_proxy_url\n        - name: NO_PROXY\n          value: 10.0.0.0/8,172.0.0.0/8";next}1' \
         "${work_dir}"/gitops/gitops-orignal.yaml > "${work_dir}"/gitops/gitops.yaml
     sed -i "s#gitops_proxy_url#${gitops_proxy_url}#" "${work_dir}"/gitops/gitops.yaml
   fi
@@ -239,7 +239,7 @@ function create_regcred() {
 
 function deploy_kraan_mgr() {
   if [ -n "${kraan_regcred}" ] ; then
-    create_regcred kraan "${kraan_regcred}"
+    create_regcred gotk-system "${kraan_regcred}"
   fi
   cp -rf "${base_dir}"/testdata/addons/kraan/manager "${work_dir}"
   if [ -n "${kraan_repo}" ] ; then
@@ -292,9 +292,8 @@ if [ $deploy_gitops -gt 0 ] ; then
   fi
 fi
 
-kubectl apply ${dry_run} -f "${base_dir}"/testdata/addons/kraan/namespace.yaml
-
 kubectl apply ${dry_run} -k "${base_dir}"/config/crd
+kubectl apply ${dry_run} -f "${base_dir}"/testdata/addons/kraan/rbac/serviceaccount.yaml
 kubectl apply ${dry_run} -f "${base_dir}"/testdata/addons/kraan/rbac/leader_election_role.yaml
 kubectl apply ${dry_run} -f "${base_dir}"/testdata/addons/kraan/rbac/leader_election_role_binding.yaml
 kubectl apply ${dry_run} -f "${base_dir}"/testdata/addons/kraan/rbac/role.yaml

--- a/testdata/addons/kraan/manager/deployment.yaml
+++ b/testdata/addons/kraan/manager/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kraan-controller
-  namespace: kraan
+  namespace: gotk-system
   labels:
     control-plane: controller
 spec:
@@ -18,6 +18,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
     spec:
+      serviceAccountName: kraan
       terminationGracePeriodSeconds: 10
       containers:
       - name: manager
@@ -33,7 +34,7 @@ spec:
           name: tmp
         args:
         - --enable-leader-election
-        - --zap-log-level=2
+        - --zap-log-level=1
         - --zap-encoder=json
         env:
           - name: DATA_PATH

--- a/testdata/addons/kraan/namespace.yaml
+++ b/testdata/addons/kraan/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kraangit

--- a/testdata/addons/kraan/rbac/leader_election_role.yaml
+++ b/testdata/addons/kraan/rbac/leader_election_role.yaml
@@ -2,8 +2,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: leader-election-role
-  namespace: kraan
+  name: kraan-leader-election-role
+  namespace: gotk-system
 rules:
 - apiGroups:
   - ""

--- a/testdata/addons/kraan/rbac/leader_election_role_binding.yaml
+++ b/testdata/addons/kraan/rbac/leader_election_role_binding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: leader-election-rolebinding
-  namespace: kraan
+  name: kraan-leader-election-rolebinding
+  namespace: gotk-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: kraan-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: kraan
+  name: kraan
+  namespace: gotk-system

--- a/testdata/addons/kraan/rbac/role_binding.yaml
+++ b/testdata/addons/kraan/rbac/role_binding.yaml
@@ -8,8 +8,8 @@ roleRef:
   name: kraan-manager
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: kraan
+  name: kraan
+  namespace: gotk-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -21,8 +21,8 @@ roleRef:
   name: kraan-gitops-source
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: kraan
+  name: kraan
+  namespace: gotk-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -34,8 +34,8 @@ roleRef:
   name: kraan-helm-release
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: kraan
+  name: kraan
+  namespace: gotk-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -47,5 +47,5 @@ roleRef:
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: kraan
+  name: kraan
+  namespace: gotk-system

--- a/testdata/addons/kraan/rbac/serviceaccount.yaml
+++ b/testdata/addons/kraan/rbac/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kraan
+  namespace: gotk-system


### PR DESCRIPTION
The Kraan Controller depends on the GOTK Helm Controller and
Source Controller and the default network policies for the
source controller service is to only allow access to pods in
the same namespace. Thus the GOTK developers recommended moving
Kraan pod into the gotk-system namespace.