### PR TITLE
Use distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,20 +5,18 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
 # Copy the go source
 COPY pkg/ pkg
 COPY main/ main
 COPY controllers/ controllers
 COPY api/ api
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
 
 # Build
 RUN mkdir bin
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o bin/kraan-controller main/main.go
-
 RUN apt install -y curl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.12/bin/linux/amd64/kubectl
 RUN chmod +x ./kubectl
@@ -28,12 +26,8 @@ RUN tar xzf ./kustomize_v3.8.5_linux_amd64.tar.gz
 RUN chmod +x ./kustomize
 RUN mv kustomize bin
 
-FROM alpine:3.12
+FROM gcr.io/distroless/static:latest
 WORKDIR /
-
 COPY --from=builder /workspace/bin/ /usr/local/bin/
-RUN addgroup -S controller && adduser -S -g controller controller
-
-USER controller
-
+USER nobody
 ENTRYPOINT ["/usr/local/bin/kraan-controller"]

--- a/Dockerfile-check
+++ b/Dockerfile-check
@@ -1,0 +1,30 @@
+# Build the manager binary
+FROM golang:1.14 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# Copy the go source
+COPY pkg/ pkg
+COPY main/ main
+COPY controllers/ controllers
+COPY api/ api
+RUN mkdir bin
+# Copy makefiles and run tests
+COPY Makefile Makefile
+COPY makefile.mk makefile.mk
+COPY project-name.mk project-name.mk
+COPY golangci-lint.yml golangci-lint.yml
+COPY bin/ bin/
+RUN apt install -y curl
+RUN bin/setup.sh
+# Temporary fix see https://github.com/fidelity/kraan/issues/114
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.12/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN mv kubectl bin
+RUN cp bin/* /usr/local/bin
+# Make
+RUN make clean
+RUN PATH=$PATH:/usr/local/kubebuilder/bin make
+

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ BUILD_DIR:=build/
 GITHUB_USER?=$(shell git config --local  user.name)
 GITHUB_ORG=$(shell git config --get remote.origin.url | sed -nr '/github.com/ s/.*github.com([^"]+).*/\1/p' | cut --characters=2- | cut -f1 -d/)
 GITHUB_REPO=$(shell git config --get remote.origin.url | sed -nr '/github.com/ s/.*github.com([^"]+).*/\1/p'| cut --characters=2- | cut -f2 -d/ | cut -f1 -d.)
-export VERSION?=latest
+export VERSION?=master
 export REPO ?=docker.pkg.github.com/${GITHUB_ORG}/${GITHUB_REPO}
 # Image URL to use all building/pushing image targets
 IMG ?= ${REPO}/${PROJECT}:${VERSION}
@@ -135,16 +135,15 @@ ${GO_BIN_ARTIFACT}: go.sum ${MAKE_SOURCES} ${PROJECT_SOURCES}
 clean-check:
 	rm -f ${CHECK_ARTIFACT}
 
-check: DOCKER_SOURCES=Dockerfile ${MAKE_SOURCES} ${PROJECT_SOURCES}
-check: DOCKER_BUILD_OPTIONS=--target builder --build-arg VERSION
-check: TAG=${REPO}/${PROJECT}-check:${VERSION}
+check: DOCKER_SOURCES=Dockerfile-check ${MAKE_SOURCES} ${PROJECT_SOURCES}
+check: DOCKER_BUILD_OPTIONS=--target builder --no-cache
+check: IMG=${PROJECT}-check:${VERSION}
 check: ${BUILD_DIR} ${CHECK_ARTIFACT}
 
 clean-build:
 	rm -f ${BUILD_ARTIFACT}
 
 build: DOCKER_SOURCES=Dockerfile ${MAKE_SOURCES} ${PROJECT_SOURCES}
-build: DOCKER_BUILD_OPTIONS=--build-arg VERSION
 build: IMG=${REPO}/${PROJECT}:${VERSION}
 build: ${BUILD_DIR} ${BUILD_ARTIFACT}
 

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: manager
-        image: docker.pkg.github.com/fidelity/kraan/kraan-controller:latest
+        image: docker.pkg.github.com/fidelity/kraan/kraan-controller:master
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
@@ -32,7 +32,7 @@ spec:
         - --zap-encoder=json
         env:
           - name: DATA_PATH
-            value: /home/controller/data
+            value: /controller/data
           - name: RUNTIME_NAMESPACE
             valueFrom:
               fieldRef:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -103,7 +103,7 @@ function args() {
   deploy_kraan=1
   deploy_gitops=1
   apply_testdata=1
-  kraan_version="latest"
+  kraan_version="master"
   no_git_auth=0
 
   arg_list=( "$@" )
@@ -246,7 +246,7 @@ function deploy_kraan_mgr() {
     sed -i "s#image\:\ docker.pkg.github.com/fidelity/kraan#image\:\ ${kraan_repo}#" "${work_dir}"/manager/deployment.yaml
   fi
   if [ -n "${kraan_version}" ] ; then
-    sed -i "s#\:latest#\:${kraan_version}#" "${work_dir}"/manager/deployment.yaml
+    sed -i "s#\:master#\:${kraan_version}#" "${work_dir}"/manager/deployment.yaml
   fi
   if [ -n "${kraan_regcred}" ] ; then
     local secret_name="regcred"

--- a/testdata/addons/kraan/manager/deployment.yaml
+++ b/testdata/addons/kraan/manager/deployment.yaml
@@ -22,13 +22,13 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: manager
-        image: docker.pkg.github.com/fidelity/kraan/kraan-controller:latest
+        image: docker.pkg.github.com/fidelity/kraan/kraan-controller:master
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
         volumeMounts:
-        - mountPath: /home/controller/data
+        - mountPath: /controller/data
           name: data
         - mountPath: /tmp
           name: tmp
@@ -38,7 +38,7 @@ spec:
         - --zap-encoder=json
         env:
           - name: DATA_PATH
-            value: /home/controller/data
+            value: /controller/data
         ports:
         - containerPort: 9440
           name: healthz


### PR DESCRIPTION
Change build to use distroless image for added security.

Also updated default image version to 'master' because docker does
not always refresh image from repoistory if it is 'latest'.

Added a Dockerfile to support running unit tests in docker container.

Tidy up developer guide.