### PR TITLE
Improve GitRepository Sync logic

### DIFF
--- a/chart/templates/kraan.yaml
+++ b/chart/templates/kraan.yaml
@@ -377,7 +377,7 @@ spec:
           name: tmp
         args:
         - --enable-leader-election
-        {{ if ne .Values.kraan.args.logLevel 0 }}
+        {{ if ne (.Values.kraan.args.logLevel | toString | atoi) 0 }}
         - --zap-log-level={{ .Values.kraan.args.logLevel }}
         {{ end }}
         - --zap-encoder=json

--- a/pkg/mocks/repos/mockRepos.go
+++ b/pkg/mocks/repos/mockRepos.go
@@ -140,6 +140,20 @@ func (mr *MockReposMockRecorder) SetHTTPClient(client interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHTTPClient", reflect.TypeOf((*MockRepos)(nil).SetHTTPClient), client)
 }
 
+// PathKey mocks base method
+func (m *MockRepos) PathKey(srcRepo *v1beta1.GitRepository) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PathKey", srcRepo)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// PathKey indicates an expected call of PathKey
+func (mr *MockReposMockRecorder) PathKey(srcRepo interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PathKey", reflect.TypeOf((*MockRepos)(nil).PathKey), srcRepo)
+}
+
 // MockRepo is a mock of Repo interface
 type MockRepo struct {
 	ctrl     *gomock.Controller

--- a/pkg/repos/repos.go
+++ b/pkg/repos/repos.go
@@ -34,6 +34,7 @@ type Repos interface {
 	SetHostName(hostName string)
 	SetTimeOut(timeOut time.Duration)
 	SetHTTPClient(client *http.Client)
+	PathKey(srcRepo *sourcev1.GitRepository) string
 }
 
 // reposData hold data about all repositories.
@@ -62,7 +63,7 @@ func NewRepos(ctx context.Context, log logr.Logger) Repos {
 	}
 }
 
-func (r *reposData) pathKey(repo *sourcev1.GitRepository) string {
+func (r *reposData) PathKey(repo *sourcev1.GitRepository) string {
 	return fmt.Sprintf("%s/%s", repo.GetNamespace(), repo.GetName())
 }
 
@@ -103,7 +104,7 @@ func (r *reposData) Get(name string) Repo {
 func (r *reposData) Add(repo *sourcev1.GitRepository) Repo {
 	r.Lock()
 	defer r.Unlock()
-	key := r.pathKey(repo)
+	key := r.PathKey(repo)
 	if _, found := r.repos[key]; !found {
 		r.repos[key] = r.newRepo(key, repo)
 	}
@@ -167,9 +168,11 @@ func (r *reposData) newRepo(path string, sourceRepo *sourcev1.GitRepository) Rep
 	return repo
 }
 
-/*func (r *repoData) getGitRepo() *sourcev1.GitRepository {
+func (r *repoData) GetGitRepo() *sourcev1.GitRepository {
+	r.RLock()
+	defer r.RUnlock()
 	return r.repo
-}*/
+}
 
 func (r *repoData) GetPath() string {
 	return r.path


### PR DESCRIPTION
Currently the kraan controller syncs the GitRepositories used by
addonslayers every time the GitReposity custom resource is updated.

This change as a check to see if the revision field in the status
of the GitRepository has changed and only proceeds with if a sync
and requeue of the addonslayers using it if revision has changed.