### PR TITLE
fix(helm chart): upgrade helm-controller image version

### DIFF
--- a/chart/templates/gitops.yaml
+++ b/chart/templates/gitops.yaml
@@ -1278,9 +1278,9 @@ spec:
           value: {{ .Values.gotk.env.noProxy }}
         {{- end }}
         {{- if .Values.gotk.image.registry }}
-        image: {{ .Values.gotk.image.registry }}/fluxcd/helm-controller:v0.1.1
+        image: {{ .Values.gotk.image.registry }}/fluxcd/helm-controller:v0.1.3
         {{- else }}
-        image: ghcr.io/fluxcd/helm-controller:v0.1.1
+        image: ghcr.io/fluxcd/helm-controller:v0.1.3
         {{- end }}
         imagePullPolicy: IfNotPresent
         livenessProbe:


### PR DESCRIPTION
In order to be able to use the `spec.valuesFrom` in a HelmRelease without
errors, the helm-controller has to be upgraded to v0.1.3.
See release notes here: https://github.com/fluxcd/helm-controller/blob/main/CHANGELOG.md#013-2020-10-16

Error seen with helm-controller:v0.1.1:
`unable to merge value from key 'my_key' in ConfigMap 'default/values-cm' into target path 'my_value': unable to parse key: assignment to entry in nil map`