### PR TITLE
Check gitrepository status condition

### DIFF
--- a/api/v1alpha1/addons_types.go
+++ b/api/v1alpha1/addons_types.go
@@ -135,6 +135,10 @@ const (
 	// PruningCondition represents the fact that the addons are being pruned.
 	PruningCondition string = "Pruning"
 
+	// PendingCondition represents the fact that the addons are pending being processed.
+	// Used when source is not ready.
+	PendingCondition string = "Pending"
+
 	// ApplyPendingCondition represents the fact that the addons are pending being applied.
 	// Used when applying is pending a prereq being met.
 	ApplyPendingCondition string = "ApplyPending"

--- a/pkg/layers/layers_test.go
+++ b/pkg/layers/layers_test.go
@@ -32,19 +32,20 @@ var (
 )
 
 const (
-	holdSet      = "hold-set"
-	k8sPending   = "k8s-pending"
-	emptyStatus  = "empty-status"
-	noDepends    = "no-depends"
-	oneDepends   = "one-depends"
-	oneDependsG  = "one-dependsG"
-	oneDependsSG = "one-dependsSG"
-	oneDependsSR = "one-dependsSR"
-	oneDependsND = "one-depends-not-deployed"
-	oneDependsV2 = "one-depends-v2"
-	twoDepends   = "two-depends"
-	k8sv16       = "k8s-v16"
-	k8sv16_2     = "k8s-v16-2"
+	holdSet       = "hold-set"
+	k8sPending    = "k8s-pending"
+	emptyStatus   = "empty-status"
+	noDepends     = "no-depends"
+	oneDepends    = "one-depends"
+	oneDependsG   = "one-dependsG"
+	oneDependsSG  = "one-dependsSG"
+	oneDependsSR  = "one-dependsSR"
+	oneDependsSNR = "one-dependsSNR"
+	oneDependsND  = "one-depends-not-deployed"
+	oneDependsV2  = "one-depends-v2"
+	twoDepends    = "two-depends"
+	k8sv16        = "k8s-v16"
+	k8sv16_2      = "k8s-v16-2"
 	//maxConditions = "max-conditions"
 	layersData  = "testdata/layersdata.json"
 	reposData   = "testdata/reposdata.json"
@@ -711,6 +712,11 @@ func TestDependenciesDeployed(t *testing.T) { // nolint: funlen // ok
 	}, {
 		name:       "check dependencies with one dependsOn, dependency not deployed",
 		layerName:  oneDependsND,
+		layersData: layersData1,
+		expected:   false,
+	}, {
+		name:       "check dependencies with one dependsOn, dependency source not ready",
+		layerName:  oneDependsSNR,
 		layersData: layersData1,
 		expected:   false,
 	},

--- a/pkg/layers/testdata/layersdata1.json
+++ b/pkg/layers/testdata/layersdata1.json
@@ -443,6 +443,76 @@
                 "observedGeneration": 2,
                 "revision": "master/abcdef"
             }
+        },
+        {
+            "apiVersion": "kraan.io/v1alpha1",
+            "kind": "AddonsLayer",
+            "metadata": {
+                "name": "one-dependsSNR",
+                "generation": 1
+            },
+            "spec": {
+                "interval": "1m",
+                "prereqs": {
+                    "dependsOn": [
+                        "no-dependsSNR@0.1.01"
+                    ]
+                },
+                "source": {
+                    "name": "gen-rev-ok",
+                    "namespace": "gotk-system",
+                    "path": "./addons/mgmt"
+                },
+                "version": "0.1.01"
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2020-08-26T13:10:13Z",
+                        "reason": "AddonsLayer is Deployed",
+                        "status": "True",
+                        "type": "Deployed",
+                        "version": "0.1.01"
+                    }
+                ],
+                "state": "Deployed",
+                "version": "0.1.01",
+                "observedGeneration": 1,
+                "revision": "master/abcdef"
+            }
+        },
+        {
+            "apiVersion": "kraan.io/v1alpha1",
+            "kind": "AddonsLayer",
+            "metadata": {
+                "name": "no-dependsSNR",
+                "generation": 2
+            },
+            "spec": {
+                "hold": false,
+                "interval": "1m",
+                "source": {
+                    "name": "cond-not-ready",
+                    "namespace": "gotk-system",
+                    "path": "./addons/bootstrap"
+                },
+                "version": "0.1.01"
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2020-08-26T13:10:13Z",
+                        "reason": "AddonsLayer is Deployed",
+                        "status": "True",
+                        "type": "Deployed",
+                        "version": "0.1.01"
+                    }
+                ],
+                "state": "Deployed",
+                "version": "0.1.01",
+                "observedGeneration": 2,
+                "revision": "master/abcdef"
+            }
         }
     ],
     "kind": "List"

--- a/pkg/layers/testdata/reposdata.json
+++ b/pkg/layers/testdata/reposdata.json
@@ -106,9 +106,47 @@
                 "conditions": [
                     {
                         "lastTransitionTime": "2020-10-23T13:39:58Z",
-                        "message": "Fetched revision: master/abcdef",
+                        "message": "Fetched revision: master/uvwxyz",
                         "reason": "GitOperationSucceed",
                         "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "observedGeneration": 2,
+                "url": "http://source-controller.gotk-system/gitrepository/gotk-system/addons-config/latest.tar.gz"
+            }
+        }, {
+            "apiVersion": "source.toolkit.fluxcd.io/v1beta1",
+            "kind": "GitRepository",
+            "metadata": {
+                "generation": 2,
+                "name": "cond-not-ready",
+                "namespace": "gotk-system"
+            },
+            "spec": {
+                "interval": "1m0s",
+                "ref": {
+                    "branch": "no-branch"
+                },
+                "secretRef": {
+                    "name": "kraan-http"
+                },
+                "url": "https://github.com/fidelity/kraan.git"
+            },
+            "status": {
+                "artifact": {
+                    "checksum": "ed8b375c560461014ba7cb85259cfe990c40a787",
+                    "lastUpdateTime": "2020-10-23T13:39:58Z",
+                    "path": "gitrepository/gotk-system/addons-config/abcdef.tar.gz",
+                    "revision": "master/uvwxyz",
+                    "url": "http://source-controller.gotk-system/gitrepository/gotk-system/addons-config/abcdef.tar.gz"
+                },
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2020-10-23T13:39:58Z",
+                        "message": "Failed to reconcile no-branch",
+                        "reason": "GitOperationFailed",
+                        "status": "False",
                         "type": "Ready"
                     }
                 ],

--- a/pkg/mocks/layers/mockLayers.go
+++ b/pkg/mocks/layers/mockLayers.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	context "context"
 	v1alpha1 "github.com/fidelity/kraan/api/v1alpha1"
+	meta "github.com/fluxcd/pkg/apis/meta"
 	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
@@ -406,4 +407,19 @@ func (m *MockLayer) GetAddonsLayer() *v1alpha1.AddonsLayer {
 func (mr *MockLayerMockRecorder) GetAddonsLayer() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAddonsLayer", reflect.TypeOf((*MockLayer)(nil).GetAddonsLayer))
+}
+
+// RevisionReady mocks base method
+func (m *MockLayer) RevisionReady(conditions []meta.Condition, revision string) (bool, string) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevisionReady", conditions, revision)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(string)
+	return ret0, ret1
+}
+
+// RevisionReady indicates an expected call of RevisionReady
+func (mr *MockLayerMockRecorder) RevisionReady(conditions, revision interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevisionReady", reflect.TypeOf((*MockLayer)(nil).RevisionReady), conditions, revision)
 }

--- a/pkg/mocks/repos/mockRepos.go
+++ b/pkg/mocks/repos/mockRepos.go
@@ -104,6 +104,20 @@ func (mr *MockReposMockRecorder) SetRootPath(path interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRootPath", reflect.TypeOf((*MockRepos)(nil).SetRootPath), path)
 }
 
+// GetRootPath mocks base method
+func (m *MockRepos) GetRootPath() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRootPath")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetRootPath indicates an expected call of GetRootPath
+func (mr *MockReposMockRecorder) GetRootPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRootPath", reflect.TypeOf((*MockRepos)(nil).GetRootPath))
+}
+
 // SetHostName mocks base method
 func (m *MockRepos) SetHostName(hostName string) {
 	m.ctrl.T.Helper()
@@ -138,20 +152,6 @@ func (m *MockRepos) SetHTTPClient(client *http.Client) {
 func (mr *MockReposMockRecorder) SetHTTPClient(client interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHTTPClient", reflect.TypeOf((*MockRepos)(nil).SetHTTPClient), client)
-}
-
-// PathKey mocks base method
-func (m *MockRepos) PathKey(srcRepo *v1beta1.GitRepository) string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PathKey", srcRepo)
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// PathKey indicates an expected call of PathKey
-func (mr *MockReposMockRecorder) PathKey(srcRepo interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PathKey", reflect.TypeOf((*MockRepos)(nil).PathKey), srcRepo)
 }
 
 // MockRepo is a mock of Repo interface
@@ -302,15 +302,15 @@ func (mr *MockRepoMockRecorder) SetHostName(hostName interface{}) *gomock.Call {
 }
 
 // SetGitRepo mocks base method
-func (m *MockRepo) SetGitRepo(src *v1beta1.GitRepository) {
+func (m *MockRepo) SetGitRepo(src *v1beta1.GitRepository, rootPath string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetGitRepo", src)
+	m.ctrl.Call(m, "SetGitRepo", src, rootPath)
 }
 
 // SetGitRepo indicates an expected call of SetGitRepo
-func (mr *MockRepoMockRecorder) SetGitRepo(src interface{}) *gomock.Call {
+func (mr *MockRepoMockRecorder) SetGitRepo(src, rootPath interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGitRepo", reflect.TypeOf((*MockRepo)(nil).SetGitRepo), src)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGitRepo", reflect.TypeOf((*MockRepo)(nil).SetGitRepo), src, rootPath)
 }
 
 // SetHTTPClient mocks base method

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,117 @@
+//Package utils contains utility functions used by multiple packages
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func CompareAsJSON(one, two interface{}) bool {
+	if one == nil && two == nil {
+		return true
+	}
+	jsonOne, err := ToJSON(one)
+	if err != nil {
+		return false
+	}
+
+	jsonTwo, err := ToJSON(two)
+	if err != nil {
+		return false
+	}
+	return jsonOne == jsonTwo
+}
+
+// LogJSON is used log an item in JSON format.
+func LogJSON(data interface{}) string {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err.Error()
+	}
+	var prettyJSON bytes.Buffer
+	err = json.Indent(&prettyJSON, jsonData, "", "  ")
+	if err != nil {
+		return err.Error()
+	}
+	return prettyJSON.String()
+}
+
+// ToJSON is used to convert a data structure into JSON format.
+func ToJSON(data interface{}) (string, error) {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return "", errors.WithMessage(err, "failed to marshal json")
+	}
+	var prettyJSON bytes.Buffer
+	err = json.Indent(&prettyJSON, jsonData, "", "\t")
+	if err != nil {
+		return "", errors.WithMessage(err, "failed indent json")
+	}
+	return prettyJSON.String(), nil
+}
+
+// GetObjNamespaceName gets object namespace and name for logging
+func GetObjNamespaceName(obj runtime.Object) (result []interface{}) {
+	mobj, ok := (obj).(metav1.Object)
+	if !ok {
+		result = append(result, "namespace", "unavailable", "name", "unavailable")
+		return result
+	}
+	result = append(result, "namespace", mobj.GetNamespace(), "name", mobj.GetName())
+	return result
+}
+
+// GetObjKindNamespaceName gets object kind namespace and name for logging
+func GetObjKindNamespaceName(obj runtime.Object) (result []interface{}) {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	result = append(result, "kind", fmt.Sprintf("%s.%s", gvk.Kind, gvk.Group))
+	result = append(result, GetObjNamespaceName(obj)...)
+	return result
+}
+
+// GetGitRepoInfo gets GitRepository details for logging
+func GetGitRepoInfo(srcRepo *sourcev1.GitRepository) (result []interface{}) {
+	result = append(result, "kind", GitRepoSourceKind())
+	result = append(result, GetObjNamespaceName(srcRepo)...)
+	result = append(result, "generation", srcRepo.Generation, "observed", srcRepo.Status.ObservedGeneration)
+	if srcRepo.Status.Artifact != nil {
+		result = append(result, "revision", srcRepo.Status.Artifact.Revision)
+	}
+	return result
+}
+
+// GitRepoSourceKind returns the gitrepository kind
+func GitRepoSourceKind() string {
+	return fmt.Sprintf("%s.%s", sourcev1.GitRepositoryKind, sourcev1.GroupVersion)
+}
+
+// RemoveIfExists removes a directory if it exists
+func RemoveIfExists(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	if e := os.RemoveAll(path); e != nil {
+		return errors.Wrap(e, "failed to remove directory")
+	}
+	return nil
+}
+
+// RemoveRecreateDir removes a directory if it exists and then recreates it
+func RemoveRecreateDir(path string) error {
+	if e := RemoveIfExists(path); e != nil {
+		return errors.WithMessage(e, "failed to remove directory before recreate")
+	}
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		return errors.Wrapf(err, "failed to make directory: %s", path)
+	}
+	return nil
+}


### PR DESCRIPTION
Added a check to the dependencies check and reconcile processing to
verify that the source GitRepository is ready. The Source Controller
does not reset the last good artifact details in the status when the
spec is changed so it is necessary to verify that the git repository
has been synced correctly.

When the Kraan-Controller processes GitRepository custom resources a log
message causes a panic if the GitRepository has no Status.Artifact
element. Created a helper function to cater for this.

Also move functions used by multiple packages to a utils package.