### PR TITLE
Fix Makefile check for CHART_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,7 @@ godocs: ${GO_DOCS_ARTIFACTS}
 
 
 release:
-ifndef CHART_VERSION
-$(error CHART_VERSION is not set)
-endif
+	test ${CHART_VERSION} || echo "please set CHART_VERSION";exit
 	git checkout -b build-release-${CHART_VERSION} || exit
 	sed -i s/appVersion\:\ v0.1.x/appVersion\:\ ${VERSION}/ chart/Chart.yaml
 	sed -i s/version\:\ v0.1.x/version\:\ ${CHART_VERSION}/ chart/Chart.yaml


### PR DESCRIPTION
Previously added a check for the CHART_VERSION variable to the release
target but inadvertently caused it to require CHART_VERSION for all
targets.