### PR TITLE
Support updateVersion annotation

### DIFF
--- a/testdata/addons/bootstrap/integration-test.yaml
+++ b/testdata/addons/bootstrap/integration-test.yaml
@@ -1,8 +1,10 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
-  name: microservice-2
+  name: integration-test
   namespace: bootstrap
+  annotations:
+    kraan.updateVersion: "true"
 spec:
   install:
     remediation:
@@ -10,6 +12,11 @@ spec:
   upgrade:
     remediation:
       retries: -1
+  dependsOn:
+    - name: microservice-1
+      namespace: bootstrap
+    - name: microservice-2
+      namespace: bootstrap      
   chart:
     spec:
       chart: podinfo
@@ -38,5 +45,5 @@ spec:
         enabled: true
         type: ClusterIP
       replicaCount: 1
-      message: -Microservice Test 2
+      message: Integration Test
   interval: 1m0s

--- a/testdata/addons/bootstrap/microservice1.yaml
+++ b/testdata/addons/bootstrap/microservice1.yaml
@@ -19,8 +19,8 @@ spec:
         namespace: gotk-system
       version: '>4.0.0'
   test:
-    enable: false
-    ignoreFailures: false
+    enable: true
+    ignoreFailures: true
     timeout: "2m"
   values:
     preHookBackoffLimit: 1


### PR DESCRIPTION
See https://github.com/fidelity/kraan/issues/148, this patch
implements a check of HelmRelease source definitions for an
annotation of kraan.updateVersion: true. If this is present
a value with key kraanVersion will be added to the chart
containing the current addonsLayer version. If this is
different from the verision set when the HelmRelease was
previously deployed it will cause the HelmRelease to be redeployed.