### PR TITLE
fix: make release publishing idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,9 +115,9 @@ release:
 	cp -rf ${RELEASE_DIR}/* . || exit
 	rm -rf ${RELEASE_DIR} || exit
 	helm repo index --url https://fidelity.github.io/kraan/ .  || exit
-	git add kraan-controller-helm-${CHART_VERSION}.tgz
+	git add -A
 	git status
-	git commit -a -m "release chart version ${CHART_VERSION}"  || exit
+	git commit -m "release chart version ${CHART_VERSION}"  || exit
 	git push  || exit
 	git checkout ${GIT_BRANCH}  || exit
 


### PR DESCRIPTION
## Summary
- stage all generated release files on the gh-pages branch before committing
- commit the staged release snapshot directly so new markdown files like CHANGELOG.md do not remain untracked and block checkout back to the release branch

## Notes
- Helm chart packaging and publishing behavior is unchanged
- repository tagging behavior is unchanged

## Validation
- make validate-versions
- make -n release